### PR TITLE
Adding quotes around Configuration names 

### DIFF
--- a/src/fix-libraries.js
+++ b/src/fix-libraries.js
@@ -1,5 +1,6 @@
 const chalk = require('chalk');
 const path = require('path');
+const util = require('util');
 
 const utilities = require('./utilities');
 
@@ -44,7 +45,7 @@ function updateProject (project) {
 
 					// Copy that bad boy.
 					const clone = JSON.parse(JSON.stringify(sourceConfig));
-					clone.name = destinationBuildConfig;
+					clone.name =  util.format('"%s"', destinationBuildConfig);
 
 					const configurationUuid = project.generateUuid();
 					const configurationCommentKey = `${configurationUuid}_comment`;

--- a/src/fix-libraries.js
+++ b/src/fix-libraries.js
@@ -1,6 +1,5 @@
 const chalk = require('chalk');
 const path = require('path');
-const util = require('util');
 
 const utilities = require('./utilities');
 
@@ -45,7 +44,7 @@ function updateProject (project) {
 
 					// Copy that bad boy.
 					const clone = JSON.parse(JSON.stringify(sourceConfig));
-					clone.name =  util.format('"%s"', destinationBuildConfig);
+					clone.name = `"${destinationBuildConfig}"`;
 
 					const configurationUuid = project.generateUuid();
 					const configurationCommentKey = `${configurationUuid}_comment`;


### PR DESCRIPTION
## Description of changes
This ensures that Configuration names with spaces don’t break library project files.


## Related issues (if any)
Fixes #2 
