### PR TITLE
Local IP handling and current react-native-xcode.sh changes

### DIFF
--- a/lib/react-native-xcode.sh
+++ b/lib/react-native-xcode.sh
@@ -45,6 +45,9 @@ cd ..
 # Define NVM_DIR and source the nvm.sh setup script
 [ -z "$NVM_DIR" ] && export NVM_DIR="$HOME/.nvm"
 
+# Define entry file
+ENTRY_FILE=${1:-index.ios.js}
+
 if [[ -s "$HOME/.nvm/nvm.sh" ]]; then
   . "$HOME/.nvm/nvm.sh"
 elif [[ -x "$(command -v brew)" && -s "$(brew --prefix nvm)/nvm.sh" ]]; then
@@ -53,7 +56,7 @@ fi
 
 # Set up the nodenv node version manager if present
 if [[ -x "$HOME/.nodenv/bin/nodenv" ]]; then
-  eval "$($HOME/.nodenv/bin/nodenv init -)"
+  eval "$("$HOME/.nodenv/bin/nodenv" init -)"
 fi
 
 [ -z "$NODE_BINARY" ] && export NODE_BINARY="node"
@@ -74,14 +77,38 @@ type $NODE_BINARY >/dev/null 2>&1 || nodejs_not_found
 set -x
 DEST=$CONFIGURATION_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH
 
+eval 'case "$CONFIGURATION" in
+  '$DEVELOPMENT_BUILD_CONFIGURATIONS')
+  if [[ ! "$PLATFORM_NAME" == *simulator ]]; then
+    PLISTBUDDY='/usr/libexec/PlistBuddy'
+    PLIST=$TARGET_BUILD_DIR/$INFOPLIST_PATH
+    IP=$(ipconfig getifaddr en0)
+    if [ -z "$IP" ]; then
+      IP=$(ifconfig | grep 'inet ' | grep -v 127.0.0.1 | cut -d\   -f2  | awk 'NR==1{print $1}')
+    fi
+    $PLISTBUDDY -c "Add NSAppTransportSecurity:NSExceptionDomains:localhost:NSTemporaryExceptionAllowsInsecureHTTPLoads bool true" "$PLIST"
+    $PLISTBUDDY -c "Add NSAppTransportSecurity:NSExceptionDomains:$IP.xip.io:NSTemporaryExceptionAllowsInsecureHTTPLoads bool true" "$PLIST"
+    echo "$IP.xip.io" > "$DEST/ip.txt"
+  fi
+esac'
+
+BUNDLE_FILE="$DEST/main.jsbundle"
+
 $NODE_BINARY "$REACT_NATIVE_DIR/local-cli/cli.js" bundle \
-  --entry-file index.ios.js \
+  --entry-file "$ENTRY_FILE" \
   --platform ios \
   --dev $DEV \
-  --bundle-output "$DEST/main.jsbundle" \
+  --reset-cache \
+  --bundle-output "$BUNDLE_FILE" \
   --assets-dest "$DEST"
 
 # XCode randomly generates user specific workspace files whenever it feels like it.
 # We want these hidden at all times, so go ahead and clean up if they're showing now.
 cd "$SCHEMES_MANAGER_DIR/../.."
 $NODE_BINARY "$SCHEMES_MANAGER_DIR/index.js" hide-library-schemes
+
+if [[ ! $DEV && ! -f "$BUNDLE_FILE" ]]; then
+  echo "error: File $BUNDLE_FILE does not exist. This must be a bug with" >&2
+  echo "React Native, please report it here: https://github.com/facebook/react-native/issues"
+  exit 2
+fi


### PR DESCRIPTION
## Description of changes

This adds in current updates to react-native-xcode.sh including the addition of automatic IP detection for iOS. This was first implemented back in RN 0.29 (original commit for reference: https://github.com/facebook/react-native/commit/8c29a52c54392ce52148e7d3aa9f835537453aa4) to enable automatically configuring an iOS device to find the packager running on the development computer when testing debug builds.


## Related issues (if any)

None
