### PR TITLE
1.0.0 beta.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ This configuration will copy the "Debug" build configuration to "Staging" and "P
 
 Some Debug schemes will use the packager and some will use the JavaScript code that is bundled into the app itself.  If you want a Debug scheme to use the bundled code, add the name of the scheme to the `bundledDebugSchemes` array.  This configuration will cause the "Preflight" scheme to go through the bundling step in the build process, while the "Staging" scheme will skip this step.
 
+If your Xcode project is not in a directory called, "ios".  You can specify the directory using a `--ios-project-dir` command line argument.  See below for an example.
+
 ## What Then?
 
 The package is able to do three things:
@@ -74,6 +76,10 @@ You can run the three parts of this package on demand by running either:
 And of course you can run all 3 easily if you'd prefer:
 
 - `react-native-schemes-manager all`: Runs all the scripts above.
+
+If your Xcode project is in a non-standard directory, you could run all three parts of the package using:
+
+- `react-native-schemes-manager all --ios-project-dir=iOS`
 
 The best way to give yourself a manual trigger for this is add to your `package.json` scripts section like so:
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ or
 npm install --save-dev react-native-schemes-manager
 ```
 
-Once the package is installed in your project, you just need to configure it by adding an `xcodeSchemes` section to your `package.json` and adding a `postinstall` script which will re-run the script whenever you add or remove packages to/from your project:
+Once the package is installed in your project, you just need to configure it by adding an `xcodeSchemes` section and an optional `bundledDebugSchemes` section to your `package.json` and adding a `postinstall` script which will re-run the script whenever you add or remove packages to/from your project:
 
 ```json
 {
@@ -31,12 +31,16 @@ Once the package is installed in your project, you just need to configure it by 
 		"postinstall": "react-native-schemes-manager all"
 	},
 	"xcodeSchemes": {
-		"Debug": ["Staging", "Preflight"]
-	}
+		"Debug": ["Staging", "Preflight"],
+		"Release": ["Beta"]
+	},
+	"bundledDebugSchemes": ["Preflight"]
 }
 ```
 
-This configuration will copy the "Debug" build configuration to "Staging" and "Preflight" build configurations in all your dependent library projects.
+This configuration will copy the "Debug" build configuration to "Staging" and "Preflight" build configurations in all your dependent library projects.  This configuration will also copy the "Release" build configuration to the "Beta" build configuration for all of the dependent libraries.  The "Debug" and "Release" arrays are both optional.
+
+Some Debug schemes will use the packager and some will use the JavaScript code that is bundled into the app itself.  If you want a Debug scheme to use the bundled code, add the name of the scheme to the `bundledDebugSchemes` array.  This configuration will cause the "Preflight" scheme to go through the bundling step in the build process, while the "Staging" scheme will skip this step.
 
 ## What Then?
 

--- a/README.md
+++ b/README.md
@@ -42,8 +42,6 @@ This configuration will copy the "Debug" build configuration to "Staging" and "P
 
 Some Debug schemes will use the packager and some will use the JavaScript code that is bundled into the app itself.  If you want a Debug scheme to use the bundled code, add the name of the scheme to the `bundledDebugSchemes` array.  This configuration will cause the "Preflight" scheme to go through the bundling step in the build process, while the "Staging" scheme will skip this step.
 
-If your Xcode project is not in a directory called, "ios".  You can specify the directory using a `--ios-project-dir` command line argument.  See below for an example.
-
 ## What Then?
 
 The package is able to do three things:
@@ -76,10 +74,6 @@ You can run the three parts of this package on demand by running either:
 And of course you can run all 3 easily if you'd prefer:
 
 - `react-native-schemes-manager all`: Runs all the scripts above.
-
-If your Xcode project is in a non-standard directory, you could run all three parts of the package using:
-
-- `react-native-schemes-manager all --ios-project-dir=iOS`
 
 The best way to give yourself a manual trigger for this is add to your `package.json` scripts section like so:
 

--- a/index.js
+++ b/index.js
@@ -5,23 +5,22 @@ yargs
 .usage('$0 command')
 .command('all', 'run all bundled commands', yargs => {
 	const operations = require('./src');
-	console.log("yargs", yargs)
 
 	for (const key of Object.keys(operations)) {
-		operations[key]();
+		operations[key](yargs.argv);
 	}
 })
 .command('fix-libraries', 'add any missing build configurations to all xcode projects in node_modules', yargs => {
-	require('./src/fix-libraries')();
+	require('./src/fix-libraries')(yargs.argv);
 })
 .command('fix-script', 'replace the react native ios bundler with our scheme aware one', yargs => {
-	require('./src/fix-script')();
+	require('./src/fix-script')(yargs.argv);
 })
 .command('hide-library-schemes', `hide any schemes that come from your node modules directory so they don't clutter up the menu.`, yargs => {
-	require('./src/hide-library-schemes')();
+	require('./src/hide-library-schemes')(yargs.argv);
 })
 .command('verify-config', `check the configuration and ensure we have both a postinstall script and xcodeSchemes configurations.`, yargs => {
-	require('./src/verify-config')();
+	require('./src/verify-config')(yargs.argv);
 })
 .demand(1, 'must provide a valid command')
 .help('h')

--- a/index.js
+++ b/index.js
@@ -5,7 +5,6 @@ yargs
 .usage('$0 command')
 .command('all', 'run all bundled commands', yargs => {
 	const operations = require('./src');
-	console.log("yargs" yargs)
 
 	for (const key of Object.keys(operations)) {
 		operations[key]();

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ yargs
 .usage('$0 command')
 .command('all', 'run all bundled commands', yargs => {
 	const operations = require('./src');
-	console.log("yargs", yargs)
+	console.log("yargs" yargs)
 
 	for (const key of Object.keys(operations)) {
 		operations[key]();

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ yargs
 .usage('$0 command')
 .command('all', 'run all bundled commands', yargs => {
 	const operations = require('./src');
+	console.log("yargs" yargs)
 
 	for (const key of Object.keys(operations)) {
 		operations[key]();

--- a/index.js
+++ b/index.js
@@ -5,22 +5,23 @@ yargs
 .usage('$0 command')
 .command('all', 'run all bundled commands', yargs => {
 	const operations = require('./src');
+	console.log("yargs", yargs)
 
 	for (const key of Object.keys(operations)) {
-		operations[key](yargs.argv);
+		operations[key]();
 	}
 })
 .command('fix-libraries', 'add any missing build configurations to all xcode projects in node_modules', yargs => {
-	require('./src/fix-libraries')(yargs.argv);
+	require('./src/fix-libraries')();
 })
 .command('fix-script', 'replace the react native ios bundler with our scheme aware one', yargs => {
-	require('./src/fix-script')(yargs.argv);
+	require('./src/fix-script')();
 })
 .command('hide-library-schemes', `hide any schemes that come from your node modules directory so they don't clutter up the menu.`, yargs => {
-	require('./src/hide-library-schemes')(yargs.argv);
+	require('./src/hide-library-schemes')();
 })
 .command('verify-config', `check the configuration and ensure we have both a postinstall script and xcodeSchemes configurations.`, yargs => {
-	require('./src/verify-config')(yargs.argv);
+	require('./src/verify-config')();
 })
 .demand(1, 'must provide a valid command')
 .help('h')

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ yargs
 .usage('$0 command')
 .command('all', 'run all bundled commands', yargs => {
 	const operations = require('./src');
-	console.log("yargs" yargs)
+	console.log("yargs", yargs)
 
 	for (const key of Object.keys(operations)) {
 		operations[key]();

--- a/lib/react-native-xcode.sh
+++ b/lib/react-native-xcode.sh
@@ -16,13 +16,18 @@ set +x
 eval 'case "$CONFIGURATION" in
   '$DEVELOPMENT_BUILD_CONFIGURATIONS')
     echo "Debug build!"
-    # Speed up build times by skipping the creation of the offline package for debug
-    # builds on the simulator since the packager is supposed to be running anyways.
-    if [[ "$PLATFORM_NAME" = "iphonesimulator" ]]; then
-      echo "Skipping bundling for Simulator platform"
-      exit 0;
-    fi
-
+    case "$CONFIGURATION" in
+      '$BUNDLED_DEVELOPMENT_BUILD_CONFIGURATIONS')
+        # do nothing here...we want to create the offline package
+        ;;
+      *)
+        # Speed up build times by skipping the creation of the offline package for debug
+        # builds on the simulator since the packager is supposed to be running anyways.
+        if [[ "$PLATFORM_NAME" = "iphonesimulator" ]]; then
+          echo "Skipping bundling for Simulator platform"
+          exit 0;
+        fi
+    esac
     DEV=true
     ;;
   "")

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "react-native-schemes-manager": "index.js"
   },
   "scripts": {
-    "postinstall": "node index.js verify-config",
     "lint": "eslint .",
     "lint-fix": "eslint . --fix"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-schemes-manager",
-  "version": "1.0.0-beta.9",
+  "version": "1.0.0-beta.10",
   "description": "Helps to manage React Native XCode projects that use multiple schemes to manage things like environment variables.",
   "main": "index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "react-native-schemes-manager": "index.js"
   },
   "scripts": {
+    "postinstall": "node index.js verify-config",
     "lint": "eslint .",
     "lint-fix": "eslint . --fix"
   },

--- a/src/fix-libraries.js
+++ b/src/fix-libraries.js
@@ -17,12 +17,12 @@ function configListForConfig (configLists, configUuid) {
 	return null;
 }
 
-function updateProject (project) {
+function updateProject (project, argv) {
 
 	const configs = project.pbxXCBuildConfigurationSection();
 	const configLists = project.pbxXCConfigurationList();
 	let changed = false;
-	const mappings = utilities.getMappings();
+	const mappings = utilities.getMappings(argv.iosProjectDir);
 
 	// Go through each mapping in our debug map and figure out if we need to clone it.
 	for (const sourceBuildConfig of Object.keys(mappings)) {
@@ -66,15 +66,15 @@ function updateProject (project) {
 	return changed;
 }
 
-module.exports = function findAndFix () {
+module.exports = function findAndFix (argv) {
 	// Find all of the pbxproj files we care about.
 	const pattern = './node_modules/**/*.xcodeproj/project.pbxproj';
 
-	utilities.updateProjectsMatchingGlob(pattern, (err, project) => {
+	utilities.updateProjectsMatchingGlob(pattern, argv.iosProjectDir, (err, project) => {
 		if (err) {
 			return console.error(chalk.red(`⃠ [fix-libraries]: Error!`, err));
 		}
 
-		return updateProject(project);
+		return updateProject(project, argv);
 	});
 };

--- a/src/fix-libraries.js
+++ b/src/fix-libraries.js
@@ -17,12 +17,12 @@ function configListForConfig (configLists, configUuid) {
 	return null;
 }
 
-function updateProject (project, argv) {
+function updateProject (project) {
 
 	const configs = project.pbxXCBuildConfigurationSection();
 	const configLists = project.pbxXCConfigurationList();
 	let changed = false;
-	const mappings = utilities.getMappings(argv.iosProjectDir);
+	const mappings = utilities.getMappings();
 
 	// Go through each mapping in our debug map and figure out if we need to clone it.
 	for (const sourceBuildConfig of Object.keys(mappings)) {
@@ -66,15 +66,15 @@ function updateProject (project, argv) {
 	return changed;
 }
 
-module.exports = function findAndFix (argv) {
+module.exports = function findAndFix () {
 	// Find all of the pbxproj files we care about.
 	const pattern = './node_modules/**/*.xcodeproj/project.pbxproj';
 
-	utilities.updateProjectsMatchingGlob(pattern, argv.iosProjectDir, (err, project) => {
+	utilities.updateProjectsMatchingGlob(pattern, (err, project) => {
 		if (err) {
 			return console.error(chalk.red(`⃠ [fix-libraries]: Error!`, err));
 		}
 
-		return updateProject(project, argv);
+		return updateProject(project);
 	});
 };

--- a/src/fix-script.js
+++ b/src/fix-script.js
@@ -16,7 +16,9 @@ function updateProject (project) {
             // Found it!
             // Need to add our actual mappings to the project.
 			const configurations = (utilities.getMappings().Debug || []).join('|');
-			const newScript = `"export NODE_BINARY=node\\nexport DEVELOPMENT_BUILD_CONFIGURATIONS=\\"${configurations}|Debug\\"\\n../node_modules/react-native-schemes-manager/lib/react-native-xcode.sh"`;
+			const devConfigs = `${configurations}${configurations.length ? '|' : ''}Debug`;
+			const bundledDebugSchemes = utilities.getBundledMappings().join('|');
+			const newScript = `"export NODE_BINARY=node\\nexport DEVELOPMENT_BUILD_CONFIGURATIONS=\\"${devConfigs}\\"\\nexport BUNDLED_DEVELOPMENT_BUILD_CONFIGURATIONS=\\"${bundledDebugSchemes}\\"\\n../node_modules/react-native-schemes-manager/lib/react-native-xcode.sh"`;
 
 			if (step.shellScript === newScript) {
                 // It's already up to date.

--- a/src/fix-script.js
+++ b/src/fix-script.js
@@ -3,7 +3,7 @@ const path = require('path');
 
 const utilities = require('./utilities');
 
-function updateProject (project) {
+function updateProject (project, argv) {
 	console.log(path.dirname(path.relative(process.cwd(), project.filepath)));
 
 	const section = project.hash.project.objects.PBXShellScriptBuildPhase;
@@ -17,7 +17,7 @@ function updateProject (project) {
             // Need to add our actual mappings to the project.
 			const configurations = (utilities.getMappings().Debug || []).join('|');
 			const devConfigs = `${configurations}${configurations.length ? '|' : ''}Debug`;
-			const bundledDebugSchemes = utilities.getBundledMappings().join('|');
+			const bundledDebugSchemes = utilities.getBundledMappings(argv.iosProjectDir).join('|');
 			const newScript = `"export NODE_BINARY=node\\nexport DEVELOPMENT_BUILD_CONFIGURATIONS=\\"${devConfigs}\\"\\nexport BUNDLED_DEVELOPMENT_BUILD_CONFIGURATIONS=\\"${bundledDebugSchemes}\\"\\n../node_modules/react-native-schemes-manager/lib/react-native-xcode.sh"`;
 
 			if (step.shellScript === newScript) {
@@ -34,15 +34,15 @@ function updateProject (project) {
 	}
 }
 
-module.exports = function findAndFix () {
+module.exports = function findAndFix (argv) {
 	// Find all of the pbxproj files we care about.
 	const pattern = './ios/*.xcodeproj/project.pbxproj';
 
-	utilities.updateProjectsMatchingGlob(pattern, (err, project) => {
+	utilities.updateProjectsMatchingGlob(pattern, argv.iosProjectDir, (err, project) => {
 		if (err) {
 			return console.error(chalk.red(`⃠ [fix-script]: Error!`, err));
 		}
 
-		return updateProject(project);
+		return updateProject(project, argv);
 	});
 };

--- a/src/fix-script.js
+++ b/src/fix-script.js
@@ -3,7 +3,7 @@ const path = require('path');
 
 const utilities = require('./utilities');
 
-function updateProject (project, argv) {
+function updateProject (project) {
 	console.log(path.dirname(path.relative(process.cwd(), project.filepath)));
 
 	const section = project.hash.project.objects.PBXShellScriptBuildPhase;
@@ -17,7 +17,7 @@ function updateProject (project, argv) {
             // Need to add our actual mappings to the project.
 			const configurations = (utilities.getMappings().Debug || []).join('|');
 			const devConfigs = `${configurations}${configurations.length ? '|' : ''}Debug`;
-			const bundledDebugSchemes = utilities.getBundledMappings(argv.iosProjectDir).join('|');
+			const bundledDebugSchemes = utilities.getBundledMappings().join('|');
 			const newScript = `"export NODE_BINARY=node\\nexport DEVELOPMENT_BUILD_CONFIGURATIONS=\\"${devConfigs}\\"\\nexport BUNDLED_DEVELOPMENT_BUILD_CONFIGURATIONS=\\"${bundledDebugSchemes}\\"\\n../node_modules/react-native-schemes-manager/lib/react-native-xcode.sh"`;
 
 			if (step.shellScript === newScript) {
@@ -34,15 +34,15 @@ function updateProject (project, argv) {
 	}
 }
 
-module.exports = function findAndFix (argv) {
+module.exports = function findAndFix () {
 	// Find all of the pbxproj files we care about.
 	const pattern = './ios/*.xcodeproj/project.pbxproj';
 
-	utilities.updateProjectsMatchingGlob(pattern, argv.iosProjectDir, (err, project) => {
+	utilities.updateProjectsMatchingGlob(pattern, (err, project) => {
 		if (err) {
 			return console.error(chalk.red(`⃠ [fix-script]: Error!`, err));
 		}
 
-		return updateProject(project, argv);
+		return updateProject(project);
 	});
 };

--- a/src/hide-library-schemes.js
+++ b/src/hide-library-schemes.js
@@ -26,13 +26,13 @@ function updateFile (file, filePath) {
 	return changed;
 }
 
-module.exports = function findAndFix (argv) {
+module.exports = function findAndFix () {
 	// Find all of the pbxproj files we care about.
 	const userSpecificPattern = './node_modules/**/*.xcodeproj/xcuserdata/*.xcuserdatad/xcschemes/xcschememanagement.plist';
 
 	console.log(chalk.gray('Hiding schemes from node_modules xcode projects.'));
 
-	utilities.updatePlistsMatchingGlob(userSpecificPattern, argv.iosProjectDir, (err, file, filePath) => {
+	utilities.updatePlistsMatchingGlob(userSpecificPattern, (err, file, filePath) => {
 		return updateFile(file, filePath);
 	});
 };

--- a/src/hide-library-schemes.js
+++ b/src/hide-library-schemes.js
@@ -26,13 +26,13 @@ function updateFile (file, filePath) {
 	return changed;
 }
 
-module.exports = function findAndFix () {
+module.exports = function findAndFix (argv) {
 	// Find all of the pbxproj files we care about.
 	const userSpecificPattern = './node_modules/**/*.xcodeproj/xcuserdata/*.xcuserdatad/xcschemes/xcschememanagement.plist';
 
 	console.log(chalk.gray('Hiding schemes from node_modules xcode projects.'));
 
-	utilities.updatePlistsMatchingGlob(userSpecificPattern, (err, file, filePath) => {
+	utilities.updatePlistsMatchingGlob(userSpecificPattern, argv.iosProjectDir, (err, file, filePath) => {
 		return updateFile(file, filePath);
 	});
 };

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -6,14 +6,15 @@ const plist = require('plist');
 const xcode = require('xcode');
 
 module.exports = {
-	getClosestLikelyReactNativeProjectPath (iosProjectDir) {
-		if (!iosProjectDir) {
-			iosProjectDir = 'ios';
+	getClosestLikelyReactNativeProjectPath (iOsProjectPath) {
+		if (!iOsProjectPath) {
+			iOsProjectPath = 'ios';
 		}
 		let currentPath = process.cwd();
+		console.log('currentPath', currentPath)
 		let nextPath;
 
-		const pattern = `${iosProjectDir}/*.xcodeproj/project.pbxproj`;
+		const pattern = `${iOsProjectPath}/*.xcodeproj/project.pbxproj`;
 		let files = glob.sync(path.join(currentPath, pattern));
 
 		while (files.length === 0) {
@@ -25,15 +26,17 @@ module.exports = {
 			}
 
 			currentPath = nextPath;
+			console.log('currentPath', currentPath)
 
 			files = glob.sync(path.join(currentPath, pattern));
+			console.log('files', files)
 		}
 
 		return currentPath;
 	},
-	getFilesMatchingGlob (pattern, iosProjectDir, callback) {
+	getFilesMatchingGlob (pattern, callback) {
         // Find all of the files we care about.
-		const project = this.getClosestLikelyReactNativeProjectPath(iosProjectDir);
+		const project = this.getClosestLikelyReactNativeProjectPath();
 		if (!project) return callback(new Error('Unable to find project path.'));
 
 		glob(path.join(project, pattern), (err, files) => {
@@ -45,8 +48,8 @@ module.exports = {
 			}
 		});
 	},
-	updateProjectsMatchingGlob (pattern, iosProjectDir, callback) {
-		this.getFilesMatchingGlob(pattern, iosProjectDir, (err, filePath) => {
+	updateProjectsMatchingGlob (pattern, callback) {
+		this.getFilesMatchingGlob(pattern, (err, filePath) => {
 			if (!filePath) return callback(new Error('Unable to find project path.'));
 			if (filePath.endsWith(path.join('Pods.xcodeproj', 'project.pbxproj'))) {
 				// The Pods.xcodeproj file isn't currently able to be parsed
@@ -71,8 +74,8 @@ module.exports = {
 			}
 		});
 	},
-	updatePlistsMatchingGlob (pattern, iosProjectDir, callback) {
-		this.getFilesMatchingGlob(pattern, iosProjectDir, (err, filePath) => {
+	updatePlistsMatchingGlob (pattern, callback) {
+		this.getFilesMatchingGlob(pattern, (err, filePath) => {
 			if (!filePath) return callback(new Error('Unable to find plist path.'));
 
 			const file = plist.parse(fs.readFileSync(filePath, 'utf8'));
@@ -83,8 +86,8 @@ module.exports = {
 			}
 		});
 	},
-	getMappings (iosProjectDir) {
-		const project = this.getClosestLikelyReactNativeProjectPath(iosProjectDir);
+	getMappings () {
+		const project = this.getClosestLikelyReactNativeProjectPath();
 		const packageJson = require(path.join(project, 'package.json'));
 
 		if (!packageJson.xcodeSchemes) {
@@ -93,8 +96,8 @@ module.exports = {
 
 		return packageJson.xcodeSchemes;
 	},
-	getBundledMappings (iosProjectDir) {
-		const project = this.getClosestLikelyReactNativeProjectPath(iosProjectDir);
+	getBundledMappings () {
+		const project = this.getClosestLikelyReactNativeProjectPath();
 		const packageJson = require(path.join(project, 'package.json'));
 
 		if (!packageJson.bundledDebugSchemes) {

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -1,3 +1,4 @@
+
 const fs = require('fs');
 const glob = require('glob');
 const path = require('path');
@@ -5,12 +6,15 @@ const plist = require('plist');
 const xcode = require('xcode');
 
 module.exports = {
-	getClosestLikelyReactNativeProjectPath () {
+	getClosestLikelyReactNativeProjectPath (iOsProjectPath) {
+		if (!iOsProjectPath) {
+			iOsProjectPath = 'ios';
+		}
 		let currentPath = process.cwd();
 		console.log('currentPath', currentPath)
 		let nextPath;
 
-		const pattern = 'ios/*.xcodeproj/project.pbxproj';
+		const pattern = `${iOsProjectPath}/*.xcodeproj/project.pbxproj`;
 		let files = glob.sync(path.join(currentPath, pattern));
 
 		while (files.length === 0) {

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -6,15 +6,14 @@ const plist = require('plist');
 const xcode = require('xcode');
 
 module.exports = {
-	getClosestLikelyReactNativeProjectPath (iOsProjectPath) {
-		if (!iOsProjectPath) {
-			iOsProjectPath = 'ios';
+	getClosestLikelyReactNativeProjectPath (iosProjectDir) {
+		if (!iosProjectDir) {
+			iosProjectDir = 'ios';
 		}
 		let currentPath = process.cwd();
-		console.log('currentPath', currentPath)
 		let nextPath;
 
-		const pattern = `${iOsProjectPath}/*.xcodeproj/project.pbxproj`;
+		const pattern = `${iosProjectDir}/*.xcodeproj/project.pbxproj`;
 		let files = glob.sync(path.join(currentPath, pattern));
 
 		while (files.length === 0) {
@@ -26,17 +25,15 @@ module.exports = {
 			}
 
 			currentPath = nextPath;
-			console.log('currentPath', currentPath)
 
 			files = glob.sync(path.join(currentPath, pattern));
-			console.log('files', files)
 		}
 
 		return currentPath;
 	},
-	getFilesMatchingGlob (pattern, callback) {
+	getFilesMatchingGlob (pattern, iosProjectDir, callback) {
         // Find all of the files we care about.
-		const project = this.getClosestLikelyReactNativeProjectPath();
+		const project = this.getClosestLikelyReactNativeProjectPath(iosProjectDir);
 		if (!project) return callback(new Error('Unable to find project path.'));
 
 		glob(path.join(project, pattern), (err, files) => {
@@ -48,8 +45,8 @@ module.exports = {
 			}
 		});
 	},
-	updateProjectsMatchingGlob (pattern, callback) {
-		this.getFilesMatchingGlob(pattern, (err, filePath) => {
+	updateProjectsMatchingGlob (pattern, iosProjectDir, callback) {
+		this.getFilesMatchingGlob(pattern, iosProjectDir, (err, filePath) => {
 			if (!filePath) return callback(new Error('Unable to find project path.'));
 			if (filePath.endsWith(path.join('Pods.xcodeproj', 'project.pbxproj'))) {
 				// The Pods.xcodeproj file isn't currently able to be parsed
@@ -74,8 +71,8 @@ module.exports = {
 			}
 		});
 	},
-	updatePlistsMatchingGlob (pattern, callback) {
-		this.getFilesMatchingGlob(pattern, (err, filePath) => {
+	updatePlistsMatchingGlob (pattern, iosProjectDir, callback) {
+		this.getFilesMatchingGlob(pattern, iosProjectDir, (err, filePath) => {
 			if (!filePath) return callback(new Error('Unable to find plist path.'));
 
 			const file = plist.parse(fs.readFileSync(filePath, 'utf8'));
@@ -86,8 +83,8 @@ module.exports = {
 			}
 		});
 	},
-	getMappings () {
-		const project = this.getClosestLikelyReactNativeProjectPath();
+	getMappings (iosProjectDir) {
+		const project = this.getClosestLikelyReactNativeProjectPath(iosProjectDir);
 		const packageJson = require(path.join(project, 'package.json'));
 
 		if (!packageJson.xcodeSchemes) {
@@ -96,8 +93,8 @@ module.exports = {
 
 		return packageJson.xcodeSchemes;
 	},
-	getBundledMappings () {
-		const project = this.getClosestLikelyReactNativeProjectPath();
+	getBundledMappings (iosProjectDir) {
+		const project = this.getClosestLikelyReactNativeProjectPath(iosProjectDir);
 		const packageJson = require(path.join(project, 'package.json'));
 
 		if (!packageJson.bundledDebugSchemes) {

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -89,4 +89,14 @@ module.exports = {
 
 		return packageJson.xcodeSchemes;
 	},
+	getBundledMappings () {
+		const project = this.getClosestLikelyReactNativeProjectPath();
+		const packageJson = require(path.join(project, 'package.json'));
+
+		if (!packageJson.bundledDebugSchemes) {
+			return [];
+		}
+
+		return packageJson.bundledDebugSchemes;
+	},
 };

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -1,4 +1,3 @@
-
 const fs = require('fs');
 const glob = require('glob');
 const path = require('path');
@@ -6,15 +5,12 @@ const plist = require('plist');
 const xcode = require('xcode');
 
 module.exports = {
-	getClosestLikelyReactNativeProjectPath (iOsProjectPath) {
-		if (!iOsProjectPath) {
-			iOsProjectPath = 'ios';
-		}
+	getClosestLikelyReactNativeProjectPath () {
 		let currentPath = process.cwd();
 		console.log('currentPath', currentPath)
 		let nextPath;
 
-		const pattern = `${iOsProjectPath}/*.xcodeproj/project.pbxproj`;
+		const pattern = 'ios/*.xcodeproj/project.pbxproj';
 		let files = glob.sync(path.join(currentPath, pattern));
 
 		while (files.length === 0) {

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -7,6 +7,7 @@ const xcode = require('xcode');
 module.exports = {
 	getClosestLikelyReactNativeProjectPath () {
 		let currentPath = process.cwd();
+		console.log('currentPath', currentPath)
 		let nextPath;
 
 		const pattern = 'ios/*.xcodeproj/project.pbxproj';
@@ -21,8 +22,10 @@ module.exports = {
 			}
 
 			currentPath = nextPath;
+			console.log('currentPath', currentPath)
 
 			files = glob.sync(path.join(currentPath, pattern));
+			console.log('files', files)
 		}
 
 		return currentPath;

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -7,7 +7,6 @@ const xcode = require('xcode');
 module.exports = {
 	getClosestLikelyReactNativeProjectPath () {
 		let currentPath = process.cwd();
-		console.log('currentPath', currentPath)
 		let nextPath;
 
 		const pattern = 'ios/*.xcodeproj/project.pbxproj';
@@ -22,10 +21,8 @@ module.exports = {
 			}
 
 			currentPath = nextPath;
-			console.log('currentPath', currentPath)
 
 			files = glob.sync(path.join(currentPath, pattern));
-			console.log('files', files)
 		}
 
 		return currentPath;

--- a/src/verify-config.js
+++ b/src/verify-config.js
@@ -3,10 +3,10 @@ const path = require('path');
 
 const utilities = require('./utilities');
 
-module.exports = function verifyConfig () {
+module.exports = function verifyConfig (argv) {
 	let packageJson = null;
 
-	const project = utilities.getClosestLikelyReactNativeProjectPath();
+	const project = utilities.getClosestLikelyReactNativeProjectPath(argv.iosProjectDir);
 	if (project) packageJson = require(path.join(project, 'package.json'));
 
 	if (!packageJson) {

--- a/src/verify-config.js
+++ b/src/verify-config.js
@@ -3,10 +3,10 @@ const path = require('path');
 
 const utilities = require('./utilities');
 
-module.exports = function verifyConfig (argv) {
+module.exports = function verifyConfig () {
 	let packageJson = null;
 
-	const project = utilities.getClosestLikelyReactNativeProjectPath(argv.iosProjectDir);
+	const project = utilities.getClosestLikelyReactNativeProjectPath();
 	if (project) packageJson = require(path.join(project, 'package.json'));
 
 	if (!packageJson) {


### PR DESCRIPTION
## Description of changes
Currently, all debug schemes exit the `react-native-xcode.sh` script before bundling is performed.

The primary purpose of this PR to to allow for Debug schemes that need the DEV flag correctly set and will be using the code produced by the bundler.

The project updates the documentation to reflect this new feature and also documents the existing capability of duplicating the Release scheme.  

It also fixes a bug that exists for configurations that do not duplicate the Debug scheme.  For example, if the user was only duplicating the Release scheme and they were not duplicating the Debug scheme, a bug existed that would cause the whole script to not work correctly.

We use an automated build process that builds our code using Jenkins on commit.  We also store our Xcode project in a non-standard directory (`iOS` instead of `ios`).  The `react-native-scheme-manager all` command was failing in the build too because it couldn't find the directory.  I added a command line arg that allows for this to be controlled but defaults to `ios` and updated the docs.

## Related issues (if any)
https://github.com/Thinkmill/react-native-schemes-manager/issues/4
https://github.com/Thinkmill/react-native-schemes-manager/issues/7
#8 