### PR TITLE
Case statement debug matching correction

### DIFF
--- a/lib/react-native-xcode.sh
+++ b/lib/react-native-xcode.sh
@@ -12,9 +12,12 @@
 
 set +x
 
+# Enable pattern matching
+shopt -s extglob
+
 # And on to your previously scheduled React Native build script programming.
 eval 'case "$CONFIGURATION" in
-  "$DEVELOPMENT_BUILD_CONFIGURATIONS")
+  $DEVELOPMENT_BUILD_CONFIGURATIONS)
     echo "Debug build!"
     # Speed up build times by skipping the creation of the offline package for debug
     # builds on the simulator since the packager is supposed to be running anyways.
@@ -83,7 +86,7 @@ set -x
 DEST=$CONFIGURATION_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH
 
 eval 'case "$CONFIGURATION" in
-  "$DEVELOPMENT_BUILD_CONFIGURATIONS")
+  $DEVELOPMENT_BUILD_CONFIGURATIONS)
   if [[ ! "$PLATFORM_NAME" == *simulator ]]; then
     PLISTBUDDY='/usr/libexec/PlistBuddy'
     PLIST=$TARGET_BUILD_DIR/$INFOPLIST_PATH

--- a/src/fix-script.js
+++ b/src/fix-script.js
@@ -16,7 +16,7 @@ function updateProject (project) {
             // Found it!
             // Need to add our actual mappings to the project.
 			const configurations = (utilities.getMappings().Debug || []).join('|');
-			const devConfigs = `${configurations}${configurations.length ? '|' : ''}Debug`;
+			const devConfigs = `+(${configurations}${configurations.length ? '|' : ''}Debug)`;
 			const newScript = `"export NODE_BINARY=node\\nexport DEVELOPMENT_BUILD_CONFIGURATIONS=\\"${devConfigs}\\"\\n../node_modules/react-native-schemes-manager/lib/react-native-xcode.sh"`;
 
 			if (step.shellScript === newScript) {


### PR DESCRIPTION
## Description of changes

The case statement in the `react-native-xcode` script was updated to use pattern matching with extended globbing so that debug build types could be identified correctly.

I have two debug builds set in my `package.json`. These would get set in the Xcode script settings like so:

`export DEVELOPMENT_BUILD_CONFIGURATIONS="Development|Staging|Debug"`

The bash case statement would not match against this pattern correctly. Running just this snippet demonstrates the problem since it will always return Production build instead of Debug:

```
DEVELOPMENT_BUILD_CONFIGURATIONS="Staging|Development|Debug"
CONFIGURATION="Staging"

eval 'case $CONFIGURATION
    in $DEVELOPMENT_BUILD_CONFIGURATIONS )
    echo "Debug build!"
    ;;
  *)
    echo "Production build!"
    ;;
esac'
```

These changes update the export statement to look like this to use with pattern matching:

`export DEVELOPMENT_BUILD_CONFIGURATIONS="+(Development|Staging|Debug)"`

For reference, a brief snippet that demonstrates the changes will print Debug build as desired:

```
shopt -s extglob
DEVELOPMENT_BUILD_CONFIGURATIONS="+(Staging|Development|Debug)"
CONFIGURATION="Staging"

eval 'case $CONFIGURATION
    in $DEVELOPMENT_BUILD_CONFIGURATIONS )
    echo "Debug build!"
    ;;
  *)
    echo "Production build!"
    ;;
esac'
```