### PR TITLE
Single Project Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ If you're still having trouble, post an issue so we can look into it.
 You can run the three parts of this package on demand by running either:
 
 - `react-native-schemes-manager fix-libraries`: Adds your build configurations to all library Xcode projects.
+	- Specify the `--single-project` parameter to fix that single Xcode project. Example: `--single-project=React`
 - `react-native-schemes-manager fix-script`: Swaps a schemes aware build script in instead of the stock react native one.
 - `react-native-schemes-manager hide-library-schemes`: Hides any build schemes that come from your node_modules folder xcodeproj files as you don't usually want to see them anyway.
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ If you're still having trouble, post an issue so we can look into it.
 You can run the three parts of this package on demand by running either:
 
 - `react-native-schemes-manager fix-libraries`: Adds your build configurations to all library Xcode projects.
-	- Specify the `--single-project` parameter to fix that single Xcode project. Example: `--single-project=React`
+- Specify the `--single-project` parameter to fix a single Xcode project. Example: `--single-project=React`
 - `react-native-schemes-manager fix-script`: Swaps a schemes aware build script in instead of the stock react native one.
 - `react-native-schemes-manager hide-library-schemes`: Hides any build schemes that come from your node_modules folder xcodeproj files as you don't usually want to see them anyway.
 

--- a/index.js
+++ b/index.js
@@ -23,10 +23,10 @@ yargs
 	require('./src/verify-config')();
 })
 .option('single-project', {
-    describe: 'Specify Xcode project name to fix single project',
-		type: 'string',
-    default: null
-  })
+	describe: 'Specify Xcode project name to fix single project',
+	type: 'string',
+	default: null,
+})
 .demand(1, 'must provide a valid command')
 .help('h')
 .alias('h', 'help')

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ yargs
 	}
 })
 .command('fix-libraries', 'add any missing build configurations to all xcode projects in node_modules', yargs => {
-	require('./src/fix-libraries')();
+	require('./src/fix-libraries')(yargs.argv.singleProject);
 })
 .command('fix-script', 'replace the react native ios bundler with our scheme aware one', yargs => {
 	require('./src/fix-script')();
@@ -22,6 +22,11 @@ yargs
 .command('verify-config', `check the configuration and ensure we have both a postinstall script and xcodeSchemes configurations.`, yargs => {
 	require('./src/verify-config')();
 })
+.option('single-project', {
+    describe: 'Specify Xcode project name to fix single project',
+		type: 'string',
+    default: null
+  })
 .demand(1, 'must provide a valid command')
 .help('h')
 .alias('h', 'help')

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ yargs
 	require('./src/verify-config')();
 })
 .option('single-project', {
-	describe: 'Specify Xcode project name to fix single project',
+	describe: 'Specify Xcode project name to fix a single project',
 	type: 'string',
 	default: null,
 })

--- a/src/fix-libraries.js
+++ b/src/fix-libraries.js
@@ -70,9 +70,13 @@ function updateProject (project) {
 	return changed;
 }
 
-module.exports = function findAndFix () {
+module.exports = function findAndFix (singleProject = null) {
 	// Find all of the pbxproj files we care about.
-	const pattern = './node_modules/**/*.xcodeproj/project.pbxproj';
+	let pattern = './node_modules/**/*.xcodeproj/project.pbxproj';
+	// Search only for specified project
+	if (singleProject) {
+		pattern = './node_modules/**/' + singleProject + '.xcodeproj/project.pbxproj';
+	}
 
 	utilities.updateProjectsMatchingGlob(pattern, (err, project) => {
 		if (err) {


### PR DESCRIPTION
## Description of changes

Added a `--single-project` option for the `fix-libraries` script to allow for fixing only a single Xcode project at a time. My primary use case for this is when installing new packages or performing React Native upgrades.  Running `fix-libraries` without this modifies all Xcode projects which creates unnecessary changes to xcodeproj files that already have the necessary schemes defined.

## Related issues (if any)

None